### PR TITLE
Max sensor input added

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,19 +157,21 @@
     </div>
 
     <div class="input-group mt-2">        
-        <i class="input-group-text bi bi-123"></i>
+        <i class="input-group-text bi bi-three-dots"></i>
         <input 
             id="sensor_input" 
             name="sensor_input" 
             type="text" 
             class="form-control" 
-            placeholder="Max number of sensors (leave blank for all)" 
+            placeholder="Max Sensors" 
             style="width:fit-content;"
             onchange="
         purple_air.state.sensorNum = this.value; 
         purple_air.hideError(); 
         console.log('Sensor Num Value Updated ==> ' + this.value)"
             >
+        <!-- hover icon for City field -->
+        <i class="input-group-text info-icon bi bi-info-circle" data-toggle="tooltip" title="Max number of sensors (leave blank for all)"></i>
     </div>
 
     <div class="d-flex justify-content-center mt-2">
@@ -206,6 +208,11 @@
     <button onclick="purple_air.enable_form_input()">Enable Form</button> -->
 </div>
 
-
+<style>
+    .info-icon{
+        background: none;
+        border: 0;
+    }
+</style>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -156,6 +156,22 @@
           </select>
     </div>
 
+    <div class="input-group mt-2">        
+        <i class="input-group-text bi bi-123"></i>
+        <input 
+            id="sensor_input" 
+            name="sensor_input" 
+            type="text" 
+            class="form-control" 
+            placeholder="Max number of sensors (leave blank for all)" 
+            style="width:fit-content;"
+            onchange="
+        purple_air.state.sensorNum = this.value; 
+        purple_air.hideError(); 
+        console.log('Sensor Num Value Updated ==> ' + this.value)"
+            >
+    </div>
+
     <div class="d-flex justify-content-center mt-2">
         <button id="reset" 
         onclick="purple_air.reset()"  

--- a/purple_air.js
+++ b/purple_air.js
@@ -122,6 +122,15 @@ var purple_air = {
         document.getElementById("minutes").selectedIndex = 0
     },
 
+    getSensorNum: function () {
+        let value = document.getElementById("sensor_input").value
+        purple_air.state.sensorNum = value
+        return value
+    },
+
+    setSensorNum: function () {
+        document.getElementById("sensor_input").value = ""
+    },
 
     clearLocationState: function () {
         purple_air.state.city = ""
@@ -157,6 +166,8 @@ var purple_air = {
         purple_air.setEndDate()
 
         purple_air.setMinutesValue()
+
+        purple_air.setSensorNum()
 
         purple_air.state = {
             ...purple_air.default
@@ -433,20 +444,39 @@ var purple_air = {
         let fetch_purple_air = await (await fetch(BASE_PURPLE_AIR_URL)).json()
 
         let data = fetch_purple_air.data
-        for (let d of data) {
 
-            let newRow = { ...purple_air_fields }
-            newRow.Location = purple_air.state.city
-            newRow.sensor_index = d[0]
-            newRow.name = d[1]
-            // newRow.primary_id_a =   d[2]
-            // newRow.primary_key_a =  d[3]
-            newRow.latitude = d[2]
-            newRow.longitude = d[3]
-            // latLngList.push( `${d[2]},${d[3]}` )
-            sensorValues.push(newRow)
-
+        // if user inputs 0 or null or greater than gathered amount of sensors
+        if (!purple_air.state.sensorNum || purple_air.state.sensorNum == 0  || purple_air.state.sensorNum >= data.length) {
+            for (let d of data) {
+                let newRow = { ...purple_air_fields }
+                newRow.Location = purple_air.state.city
+                newRow.sensor_index = d[0]
+                newRow.name = d[1]
+                // newRow.primary_id_a =   d[2]
+                // newRow.primary_key_a =  d[3]
+                newRow.latitude = d[2]
+                newRow.longitude = d[3]
+                // latLngList.push( `${d[2]},${d[3]}` )
+                sensorValues.push(newRow)
+            }
         }
+        // otherwise loop through just number of sensors the user wants
+        else {
+            for (let i = 0; i < purple_air.state.sensorNum; i++) {
+                let d = data[i]
+                let newRow = { ...purple_air_fields }
+                newRow.Location = purple_air.state.city
+                newRow.sensor_index = d[0]
+                newRow.name = d[1]
+                // newRow.primary_id_a =   d[2]
+                // newRow.primary_key_a =  d[3]
+                newRow.latitude = d[2]
+                newRow.longitude = d[3]
+                // latLngList.push( `${d[2]},${d[3]}` )
+                sensorValues.push(newRow)
+            }
+        }
+        // }
 
         // console.log(latLngList.join("|"))
         // let elevationList = await purple_air.getElevationFromLatLong(latLngList.join("|"))
@@ -699,7 +729,8 @@ purple_air.state = {
     radiusInMiles: default_radius_value,
     startDate: "",
     endDate: "",
-    averaginMinutes: 0
+    averaginMinutes: 0,
+    sensorNum: 0
 };
 
 purple_air.default = {
@@ -712,7 +743,8 @@ purple_air.default = {
     radiusInMiles: default_radius_value,
     startDate: "",
     endDate: "",
-    averaginMinutes: 0
+    averaginMinutes: 0,
+    sensorNum: 0
 }
 
 // purple_air.state = {

--- a/purple_air.js
+++ b/purple_air.js
@@ -445,47 +445,27 @@ var purple_air = {
 
         let data = fetch_purple_air.data
 
-        // if user inputs 0 or null or greater than gathered amount of sensors
-        if (!purple_air.state.sensorNum || purple_air.state.sensorNum == 0  || purple_air.state.sensorNum >= data.length) {
-            for (let d of data) {
-                let newRow = { ...purple_air_fields }
-                newRow.Location = purple_air.state.city
-                newRow.sensor_index = d[0]
-                newRow.name = d[1]
-                // newRow.primary_id_a =   d[2]
-                // newRow.primary_key_a =  d[3]
-                newRow.latitude = d[2]
-                newRow.longitude = d[3]
-                // latLngList.push( `${d[2]},${d[3]}` )
-                sensorValues.push(newRow)
+        let totalReqSensors = purple_air.state.sensorNum || 0
+        let recordsCount = 0;
+
+        for (let d of data) {
+            let newRow = { ...purple_air_fields }
+            newRow.Location = purple_air.state.city
+            newRow.sensor_index = d[0]
+            newRow.name = d[1]
+            // newRow.primary_id_a =   d[2]
+            // newRow.primary_key_a =  d[3]
+            newRow.latitude = d[2]
+            newRow.longitude = d[3]
+            // latLngList.push( `${d[2]},${d[3]}` )
+            sensorValues.push(newRow)
+
+            // Keep count of the sensor records read and terminate if max cap is reached
+            recordsCount = recordsCount + 1; 
+            if(totalReqSensors > 0 && recordsCount >= totalReqSensors){
+                break;
             }
         }
-        // otherwise loop through just number of sensors the user wants
-        else {
-            for (let i = 0; i < purple_air.state.sensorNum; i++) {
-                let d = data[i]
-                let newRow = { ...purple_air_fields }
-                newRow.Location = purple_air.state.city
-                newRow.sensor_index = d[0]
-                newRow.name = d[1]
-                // newRow.primary_id_a =   d[2]
-                // newRow.primary_key_a =  d[3]
-                newRow.latitude = d[2]
-                newRow.longitude = d[3]
-                // latLngList.push( `${d[2]},${d[3]}` )
-                sensorValues.push(newRow)
-            }
-        }
-        // }
-
-        // console.log(latLngList.join("|"))
-        // let elevationList = await purple_air.getElevationFromLatLong(latLngList.join("|"))
-        // console.log(elevationList)
-
-        // for (const [index, sensor] of sensorValues.entries()){
-        //     console.log(sensor.name, elevationList[index])
-        //     sensor.elevation = elevationList[index]
-        // }
 
         // if (flag === 1) {        console.log(sensorValues)        }
 


### PR DESCRIPTION
Adds a new input text field that lets user specify max number of sensors. Solves issue of too many sensors being retrieved (Ex: Oakland has 2500 in a 10 mile radius). If field is left blank or 0 is entered, default number of sensors will be retrieved. Also added tooltip that gives tips on hover. Another pull request will be made by another group adding these tooltips to all the input fields.